### PR TITLE
Emp store refactor

### DIFF
--- a/clo-workflows/Scripts/src/model/CloRequestElement.ts
+++ b/clo-workflows/Scripts/src/model/CloRequestElement.ts
@@ -2,7 +2,12 @@ import { IKeyValueMap } from "mobx"
 // Request Element is a process, project, or work
 // it is a plain javascript object sent from the server containing form data
 // an alternate and identical definition would be interface CloRequestElement {[field: string]: FormEntryType}
-export type CloRequestElement = IKeyValueMap<FormEntryType>
+// note values in a CloRequestElement will be strings, besides the Id assigned by SharePoint
+export type CloRequestElement = IKeyValueMap<FormEntryType> & IdentifiableObject
+
+export interface IdentifiableObject {
+    Id?: number // request elements will be assigned numbers once they are saved to the SharePoint server
+}
 
 // ensures that values of a CloRequestElement are serializable primitive values (no functions or nested objects)
 export type FormEntryType = string | number

--- a/clo-workflows/Scripts/src/model/Note.ts
+++ b/clo-workflows/Scripts/src/model/Note.ts
@@ -3,7 +3,7 @@ export interface INote {
     dateSubmitted: string
     text: string
     scope: NoteScope
-    Id?: string // will be asigned to notes that have been submitted to the server
+    Id?: number // will be asigned to notes that have been submitted to the server
     workId?: string // present if source is a work
     projectId?: string // present if source is a project
     attachedClientId?: string // present if scope is client, will be changed to attachedDepartment when departments are implemented

--- a/clo-workflows/Scripts/src/service/dataService/IDataService.ts
+++ b/clo-workflows/Scripts/src/service/dataService/IDataService.ts
@@ -22,7 +22,7 @@ export interface IDataService {
     createNote(note: INote): Promise<ItemAddResult>
     fetchNotes(source: NoteSource, scope: NoteScope, sourceId: string, attachedClientId: string): Promise<Array<INote>>
     updateNote(note: INote): Promise<void>
-    deleteNote(noteId: string): Promise<void>
+    deleteNote(noteId: number): Promise<void>
 }
 
 export enum ListName {

--- a/clo-workflows/Scripts/src/service/dataService/MockDataService.ts
+++ b/clo-workflows/Scripts/src/service/dataService/MockDataService.ts
@@ -19,7 +19,7 @@ export class MockDataService implements IDataService {
     updateNote(note: INote): Promise<void> {
         throw new Error("Method not implemented.")
     }
-    deleteNote(noteId: string): Promise<void> {
+    deleteNote(noteId: number): Promise<void> {
         throw new Error("Method not implemented.")
     }
     fetchWorks(): Promise<Array<IWork>> {

--- a/clo-workflows/Scripts/src/service/dataService/SpDataService.ts
+++ b/clo-workflows/Scripts/src/service/dataService/SpDataService.ts
@@ -139,10 +139,10 @@ export class SpDataService implements IDataService {
             .items.getById(Number(note.Id))
             .update(note)
     }
-    async deleteNote(noteId: string): Promise<void> {
+    async deleteNote(noteId: number): Promise<void> {
         await this.getHostWeb()
             .lists.getByTitle(ListName.NOTES)
-            .items.getById(Number(noteId))
+            .items.getById(noteId)
             .delete()
     }
 

--- a/clo-workflows/Scripts/src/store/EmployeeStore.ts
+++ b/clo-workflows/Scripts/src/store/EmployeeStore.ts
@@ -106,7 +106,7 @@ export class EmployeeStore {
     }
 
     @action resetSelectedWork() {
-        this.selectedWork = observable.map(this.activeWorks.get(this.selectedProject.get("workId") as string))
+        this.selectedWork = observable.map(this.activeWorks.get(this.selectedProcess.get("workId") as string))
     }
 
 

--- a/clo-workflows/Scripts/src/store/EmployeeStore.ts
+++ b/clo-workflows/Scripts/src/store/EmployeeStore.ts
@@ -571,19 +571,6 @@ export class EmployeeStore {
         this.selectedWork = null
     }
 
-    // finds the item with the with the same ID as the new item and replaces the stale item with the new item
-    // true if replacement was successfull, false if not (stale list item was not found)
-    // @action
-    // private replaceElementInListById(newItem: CloRequestElement | INote, list: Array<CloRequestElement | INote>): boolean {
-    //     const staleItemIndex = list.findIndex(listItem => listItem["Id"] === newItem["Id"])
-
-    //     if(staleItemIndex !== -1) {
-    //         list[staleItemIndex] = newItem
-    //         return true
-    //     }
-    //     return false
-    // }
-
     @action
     private removeELementInListById(itemToDelete: CloRequestElement | INote, list: Array<CloRequestElement | INote>) {
         list.splice(list.findIndex(listItem => listItem["Id"] === listItem["Id"]), 1 /*remove 1 elem*/)

--- a/clo-workflows/Scripts/src/store/StoreUtils.ts
+++ b/clo-workflows/Scripts/src/store/StoreUtils.ts
@@ -1,7 +1,6 @@
 import { FormControl } from "../model/FormControl"
-import { FormEntryType } from "../model/CloRequestElement"
-import { observable } from "mobx"
-import { ObservableMap } from "mobx/lib/types/observablemap"
+import { FormEntryType, CloRequestElement, IdentifiableObject } from "../model/CloRequestElement"
+import { observable, action, ObservableMap } from "mobx"
 
 class StoreUtils {
     private static REQUIRED_INPUT_ERROR = "this value is required"
@@ -43,6 +42,24 @@ class StoreUtils {
 
     getClientObsMap = (userId: string): ObservableMap<string> => {
         return observable.map([["submitterId", userId]])
+    }
+
+    mapRequestElementArrayById(requestElementArray: CloRequestElement[]): ObservableMap<CloRequestElement> {
+        return requestElementArray.reduce((requestElementMap, requestElement) => {
+            requestElementMap.set(String(requestElement.Id), requestElement)
+            return requestElementMap
+        }, new ObservableMap<CloRequestElement>())
+    }
+
+    @action
+    replaceElementInListById(newItem: IdentifiableObject, list: IdentifiableObject[]): boolean {
+        const staleItemIndex = list.findIndex(listItem => listItem["Id"] === newItem["Id"])
+
+        if(staleItemIndex !== -1) {
+            list[staleItemIndex] = newItem
+            return true
+        }
+        return false
     }
 }
 

--- a/clo-workflows/Scripts/test/store/RootStore_test.ts
+++ b/clo-workflows/Scripts/test/store/RootStore_test.ts
@@ -5,7 +5,7 @@ import { RootStore } from "../../src/store/RootStore"
 import { useStrict } from "mobx"
 import { when, mock, verify, instance, spy, anything } from "ts-mockito"
 import { IUser } from "../../src/model/User"
-import { MockProjects, MockUsers, MockProcesses } from "../../src/service/dataService/MockData"
+import { MockProjects, MockUsers, MockProcesses, MockWorks } from "../../src/service/dataService/MockData"
 import { MockDataService } from "../../src/service/dataService/MockDataService"
 import { ListName } from "../../src/service/dataService/IDataService"
 import { getRole } from "../../src/model/loader/resourceLoaders"
@@ -24,6 +24,7 @@ ava.test("root store creates session store, employee store when an employee logs
     when(mockDataService.fetchUser()).thenReturn(Promise.resolve(user))
     when(mockDataService.fetchEmployeeActiveProcesses(anything())).thenReturn(Promise.resolve(MockProcesses))
     when(mockDataService.fetchRequestElementsById(anything(), ListName.PROJECTS)).thenReturn(Promise.resolve(MockProjects))
+    when(mockDataService.fetchRequestElementsById(anything(), ListName.WORKS)).thenReturn(Promise.resolve(MockWorks))
     when(mockDataService.fetchClientActiveProjects(anything())).thenReturn(Promise.resolve(MockProjects))
 
     const rootStore: RootStore = new RootStore(instance(mockDataService))

--- a/clo-workflows/Scripts/tslint.json
+++ b/clo-workflows/Scripts/tslint.json
@@ -24,7 +24,8 @@
         "max-classes-per-file": false,
         "variable-name": false,
         "one-variable-per-declaration": false,
-        "trailing-comma": false
+        "trailing-comma": false,
+        "one-line": false
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
cache all requests by ID in maps (instead of arrays) - allows for more concise / faster lookup